### PR TITLE
Bug fix

### DIFF
--- a/src/Star.php
+++ b/src/Star.php
@@ -59,7 +59,10 @@ class Star
         $where = self::getWhere($starable, $starType);
 
         $user = ['user_id' => $userId];
-        $rating = ['value' => $value];
+        $rating = [	
+            'value' => $value,	
+            'created_at' => now()	
+        ];
 
         $has = DB::table('stars')->where($where + $user)->exists();
 


### PR DESCRIPTION
DB facade has no idea about created_at and it doesn't fill it automatically, so we must add it manually.